### PR TITLE
suggested fixes

### DIFF
--- a/charts/rancher-wins-upgrader/templates/_helpers.tpl
+++ b/charts/rancher-wins-upgrader/templates/_helpers.tpl
@@ -29,8 +29,17 @@ release: {{ .Release.Name }}
 provider: kubernetes
 {{- end -}}
 
+{{- define "winsUpgrader.validatePathPrefix" -}}
+{{- $pathPrefix := (required "Must provide value for .Values.global.cattle.rkeWindowsPathPrefix" .Values.global.cattle.rkeWindowsPathPrefix) -}}
+{{- if (contains "\\" $pathPrefix) -}}
+{{- fail ".Values.global.cattle.rkeWindowsPathPrefix must not contain backslashes" -}}
+{{- else if (not (hasSuffix "/" $pathPrefix)) -}}
+{{- fail ".Values.global.cattle.rkeWindowsPathPrefix must end in '/'" -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "winsUpgrader.winsHostPath" -}}
-{{ .Values.global.cattle.rkeWindowsPrefixPath | replace "\\\\" "/" }}etc/rancher/wins
+{{ .Values.global.cattle.rkeWindowsPathPrefix }}etc/rancher/wins
 {{- end -}}
 
 {{- define "winsUpgrader.winsMasqueradeHostPath" -}}

--- a/charts/rancher-wins-upgrader/templates/configmap.yaml
+++ b/charts/rancher-wins-upgrader/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{ include "winsUpgrader.validatePathPrefix" . }}
 {{- range .Values.winsConfigs }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/rancher-wins-upgrader/values.yaml
+++ b/charts/rancher-wins-upgrader/values.yaml
@@ -17,24 +17,25 @@ winsConfigs:
     # TODO(aiyengar2): replace with an image that just contains wins
     repository: rancher/wins
     tag: v0.1.0
+    os: "windows"
   config: |
     debug: false
     listen: rancher_wins
     proxy: rancher_wins_proxy
     whiteList:
       processPaths:
-        - {{ .Values.global.cattle.rkeWindowsPrefixPath }}etc/rancher/wins/wins-upgrade.exe
-        - {{ .Values.global.cattle.rkeWindowsPrefixPath }}etc/windows-exporter/windows-exporter.exe
-        - {{ .Values.global.cattle.rkeWindowsPrefixPath }}etc/wmi-exporter/wmi-exporter.exe
-        - {{ .Values.global.cattle.rkeWindowsPrefixPath }}etc/kubernetes/bin/kube-proxy.exe
-        - {{ .Values.global.cattle.rkeWindowsPrefixPath }}etc/kubernetes/bin/kubelet.exe
-        - {{ .Values.global.cattle.rkeWindowsPrefixPath }}etc/nginx/nginx.exe
-        - {{ .Values.global.cattle.rkeWindowsPrefixPath }}opt/bin/flanneld.exe
+        - {{ .Values.global.cattle.rkeWindowsPathPrefix }}etc/rancher/wins/wins-upgrade.exe
+        - {{ .Values.global.cattle.rkeWindowsPathPrefix }}etc/windows-exporter/windows-exporter.exe
+        - {{ .Values.global.cattle.rkeWindowsPathPrefix }}etc/wmi-exporter/wmi-exporter.exe
+        - {{ .Values.global.cattle.rkeWindowsPathPrefix }}etc/kubernetes/bin/kube-proxy.exe
+        - {{ .Values.global.cattle.rkeWindowsPathPrefix }}etc/kubernetes/bin/kubelet.exe
+        - {{ .Values.global.cattle.rkeWindowsPathPrefix }}etc/nginx/nginx.exe
+        - {{ .Values.global.cattle.rkeWindowsPathPrefix }}opt/bin/flanneld.exe
       proxyPorts:
         - 9796
     upgrade:
       mode: watching
-      watchingPath: {{ .Values.global.cattle.rkeWindowsPrefixPath }}etc/rancher/wins/wins.exe
+      watchingPath: {{ .Values.global.cattle.rkeWindowsPathPrefix }}etc/rancher/wins/wins.exe
   # By default, `kubernetes.io/os: windows` or `beta.kubernetes.io/os: windows` will be included
   nodeSelector: {}
   # If provided, these tolerations will be used. Otherwise, it defaults to `[ {operator: Exists} ]`
@@ -56,4 +57,4 @@ masquerade:
   # wmi_exporter is the only default whitelisted process that may or may not be run on the host, since
   # it is only ever deployed if the Windows cluster is also using Prometheus-based Windows monitoring (e.g. Rancher Monitoring V1)
   # All of the other default whitelisted processes are required for the Kubernetes cluster to operate
-  as: {{ .Values.global.cattle.rkeWindowsPrefixPath  }}etc/wmi-exporter/wmi-exporter.exe
+  as: "{{ .Values.global.cattle.rkeWindowsPathPrefix  }}etc/wmi-exporter/wmi-exporter.exe"


### PR DESCRIPTION
I ran this through `helm template -n cattle-wins-system rancher-wins-upgrade ./charts/rancher-wins-upgrader > output.yaml` and found the following fixes.

Namely:
- Needed to change rkeWindowsPrefixPath to rkeWindowsPathPrefix
- added os annotation from comment (this will make it easier to make the rancher/charts PR since you don't have to maintain a patch anymore)
- Updated `winsUpgrader.validatePathPrefix` that gets called whenever the chart is rendered to ensure the pathPrefix is non-empty, ends in / and does not have backslashes on render. This removes the need for the replace call.